### PR TITLE
Add .gitignore for Go project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ vendor/
 go.work
 go.work.sum
 
-# Binary with project name
-devslot
+# Binary with project name (only at root)
+/devslot
 
 # IDE specific files
 .idea/


### PR DESCRIPTION
## Summary
- Add comprehensive .gitignore file for Go project
- Exclude common build artifacts, IDE files, and OS-specific files
- Prevent tracking of compiled binaries and temporary files

## Test plan
- [x] Verify .gitignore syntax is valid
- [x] Confirm appropriate patterns for Go projects
- [x] Check that common IDE and OS files are excluded

🤖 Generated with Claude Code