### PR TITLE
Add GoReleaser CD pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,60 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./main.go
+    binary: devslot
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: yammerjp
+    name: devslot
+  draft: false
+  prerelease: auto
+  name_template: "v{{.Version}}"
+  mode: append


### PR DESCRIPTION
## Summary
- GoReleaserを使用した自動リリースパイプラインの追加
- GitHub Actionsによるタグプッシュ時の自動ビルド・リリース
- マルチプラットフォーム対応（Linux, Windows, macOS / amd64, arm64）

## Changes
- `.goreleaser.yaml`: GoReleaserの設定ファイル
  - クロスプラットフォームビルドの設定
  - バージョン情報の埋め込み
  - アーカイブとチェックサムの生成
  - Changelogの自動生成
- `.github/workflows/release.yaml`: リリース用GitHub Actionsワークフロー
  - `v*`タグプッシュ時に自動実行
  - GoReleaserを使用したビルドとリリース作成

## Test plan
- [ ] `goreleaser check`でローカル設定の検証
- [ ] テストタグをプッシュしてワークフローの動作確認
- [ ] 生成されるバイナリの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)