### PR TITLE
Fix version embedding for GoReleaser builds

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func (cmd *DoctorCmd) Run(ctx *Context) error {
 	return fmt.Errorf("not implemented")
 }
 
-const version = "0.1.0"
+var version = "dev"
 
 type VersionCmd struct{}
 


### PR DESCRIPTION
## Summary
- GoReleaserでビルドしたバイナリが正しいバージョン番号を表示するよう修正

## Problem
- v0.2.0でリリースしたバイナリが`devslot version`実行時に「0.1.0」を表示していた
- 原因: `const version`では`ldflags`による値の上書きができない

## Solution  
- `const version = "0.1.0"`を`var version = "dev"`に変更
- これにより`ldflags`の`-X main.version={{.Version}}`が有効になる

## Test
ローカルでGoReleaserビルドをテスト済み:
```bash
$ goreleaser build --snapshot --clean --single-target
$ ./dist/devslot_darwin_arm64_v8.0/devslot version
devslot version 0.2.1-next
```

🤖 Generated with [Claude Code](https://claude.ai/code)