### PR TITLE
Fix: APP_IDをシークレットから読み取るように修正

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -23,7 +23,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Run tagpr

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -63,7 +63,7 @@ GitHub AppsはPATと比較して、より優れたセキュリティと管理機
    - App ID（App設定に表示）をメモ
    - リポジトリの Settings > Secrets and variables > Actions へ移動
    - シークレット`APP_PRIVATE_KEY`に.pemファイルの内容を追加
-   - 変数`APP_ID`にApp IDを追加
+   - シークレット`APP_ID`にApp IDを追加
 
 5. サンプルワークフローを使用:
    ```bash


### PR DESCRIPTION
## 問題
tagprワークフローが失敗していた原因：
- APP_IDを変数（vars）から読み取ろうとしていた
- 実際にはシークレットとして設定されていた

## 修正内容
- `vars.APP_ID` → `secrets.APP_ID` に変更
- ドキュメントも修正

これでtagprが正常に動作するはずです。

🤖 Generated with [Claude Code](https://claude.ai/code)