### PR TITLE
Simplify tagpr workflow

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -18,16 +18,7 @@ jobs:
         with:
           persist-credentials: true
 
-      # Generate GitHub App token that can trigger other workflows
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Run tagpr
         uses: Songmu/tagpr@v1
         env:
-          # Use GitHub App token to allow triggering release workflow
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub Appの設定に問題があるため、一旦基本的なGITHUB_TOKENを使用する設定に戻します。

これにより：
- tagprが正常に動作してリリースPRを作成できるようになります
- ただし、tagprが作成したタグではrelease.yamlは自動的にトリガーされません（手動実行が必要）

GitHub Appのセットアップは別途確認が必要です。

🤖 Generated with [Claude Code](https://claude.ai/code)