### PR TITLE
Add clarifying comment about version override

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func (cmd *DoctorCmd) Run(ctx *Context) error {
 }
 
 // version must be var in main package for GoReleaser ldflags
+// This value is overridden by GoReleaser during release builds
 var version = "dev"
 
 type VersionCmd struct{}


### PR DESCRIPTION
小さなドキュメント改善です。

バージョン変数がリリースビルド時にGoReleaserによって上書きされることを明確に説明するコメントを追加しました。

この変更により、tagprの動作も確認できます。

🤖 Generated with [Claude Code](https://claude.ai/code)