### PR TITLE
Fix tagpr configuration and set version to 0.2.1

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -14,8 +14,3 @@
     # Create GitHub releases
     release = true
     
-    # Major version string in version file
-    majorVersionString = var version = "{{.Major}}.0.0"
-    
-    # Minor version string in version file
-    minorVersionString = var version = "{{.Major}}.{{.Minor}}.0"

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func (cmd *DoctorCmd) Run(ctx *Context) error {
 
 // version must be var in main package for GoReleaser ldflags
 // This value is overridden by GoReleaser during release builds
-var version = "dev"
+var version = "0.2.1"
 
 type VersionCmd struct{}
 


### PR DESCRIPTION
## 問題
tagprがバージョンを検出できずにエラーになっていました。

## 修正内容
1. .tagprから不正なバージョン文字列パターンを削除
2. main.goのバージョンを手動で0.2.1に設定

これでtagprが正常に動作し、v0.2.1タグとリリースが作成されるはずです。

🤖 Generated with [Claude Code](https://claude.ai/code)