### PR TITLE
Configure tagpr to use git tags only

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -14,8 +14,3 @@
     # Create GitHub releases
     release = true
     
-    # Major version string in version file
-    majorVersionString = var version = "{{.Major}}.0.0"
-    
-    # Minor version string in version file
-    minorVersionString = var version = "{{.Major}}.{{.Minor}}.0"

--- a/.tagpr
+++ b/.tagpr
@@ -2,8 +2,8 @@
     # Release branch
     releaseBranch = main
     
-    # Version file - main.go contains the version variable
-    versionFile = main.go
+    # Version file - use git tags only (no version file)
+    versionFile = -
     
     # Add v prefix to tags (e.g. v0.2.0)
     vPrefix = true

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func (cmd *DoctorCmd) Run(ctx *Context) error {
 
 // version must be var in main package for GoReleaser ldflags
 // This value is overridden by GoReleaser during release builds
-var version = "0.2.1"
+var version = "dev"
 
 type VersionCmd struct{}
 

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func (cmd *DoctorCmd) Run(ctx *Context) error {
 
 // version must be var in main package for GoReleaser ldflags
 // This value is overridden by GoReleaser during release builds
-var version = "dev"
+var version = "0.2.1"
 
 type VersionCmd struct{}
 


### PR DESCRIPTION
## 問題
tagprが「no version detected from file: main.go」エラーで失敗していました。

原因：
- tagprはGoファイルから形式のセマンティックバージョンを探す
- 我々のコードはを使用している
- GoReleaserがビルド時にldflagsで実際のバージョンを注入する設計

## 解決策
のをに設定して、ファイルベースのバージョン管理を無効化し、gitタグのみでバージョン管理を行います。

これにより：
- tagprはgitタグからバージョンを取得
- main.goのはそのまま維持
- GoReleaserがリリース時に正しいバージョンを注入

🤖 Generated with [Claude Code](https://claude.ai/code)