### PR TITLE
Integrate GoReleaser into tagpr workflow

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -27,7 +27,25 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Run tagpr
+        id: tagpr
         uses: Songmu/tagpr@v1
         env:
           # Use GitHub App token to allow triggering release workflow
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Run GoReleaser when tagpr creates a tag
+      - name: Set up Go
+        if: steps.tagpr.outputs.tag != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser
+        if: steps.tagpr.outputs.tag != ''
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 問題
GitHub Appトークンで作成されたタグは、別のワークフローをトリガーしません。
これはGitHub Actionsのセキュリティ機能で、無限ループを防ぐためです。

## 解決策
tagprワークフロー内でGoReleaserを直接実行します。
- tagprのを使用して、タグが作成された場合のみリリースステップを実行
- 同じワークフロー内で実行するため、トリガーの問題を回避

## 動作フロー
1. mainブランチへのプッシュ → tagpr実行
2. リリースPRマージ時 → tagprがタグ作成 → 同じワークフロー内でGoReleaser実行
3. 通常のプッシュ時 → tagprのみ実行（GoReleaserはスキップ）

🤖 Generated with [Claude Code](https://claude.ai/code)