### PR TITLE
Fix help display and improve CLI usability

### DIFF
--- a/cmd/devslot/main.go
+++ b/cmd/devslot/main.go
@@ -31,7 +31,6 @@ func NewApp(writer io.Writer) *App {
 	parser, err := kong.New(cli,
 		kong.Name("devslot"),
 		kong.Description("Development environment manager for multi-repo worktrees"),
-		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact: true,
 		}),
@@ -52,6 +51,12 @@ func NewApp(writer io.Writer) *App {
 }
 
 func (app *App) Run(args []string) error {
+	// Show help if no arguments provided
+	if len(args) == 0 {
+		_, _ = app.parser.Parse([]string{"--help"})
+		return nil
+	}
+
 	ctx, err := app.parser.Parse(args)
 	if err != nil {
 		return err

--- a/cmd/devslot/main.go
+++ b/cmd/devslot/main.go
@@ -9,14 +9,16 @@ import (
 )
 
 type CLI struct {
-	Boilerplate command.BoilerplateCmd `cmd:"" help:"Create boilerplate structure for a new project"`
-	Init        command.InitCmd        `cmd:"" help:"Initialize the project by syncing bare repositories"`
-	Create      command.CreateCmd      `cmd:"" help:"Create a new slot"`
-	Destroy     command.DestroyCmd     `cmd:"" help:"Destroy an existing slot"`
-	Reload      command.ReloadCmd      `cmd:"" help:"Reload a slot to ensure all worktrees exist"`
+	Boilerplate command.BoilerplateCmd `cmd:"" help:"Generate initial project structure in current directory"`
+	Init        command.InitCmd        `cmd:"" help:"Sync bare repositories defined in devslot.yaml into repos/"`
+	Create      command.CreateCmd      `cmd:"" help:"Create a new slot (multi-repo worktree environment)"`
+	Destroy     command.DestroyCmd     `cmd:"" help:"Remove the specified slot (runs pre-destroy hook first)"`
+	Reload      command.ReloadCmd      `cmd:"" help:"Ensure all worktrees exist for the slot and run post-reload hook"`
 	List        command.ListCmd        `cmd:"" help:"List all existing slots"`
-	Doctor      command.DoctorCmd      `cmd:"" help:"Check project consistency and show diagnostics"`
-	Version     command.VersionCmd     `cmd:"" help:"Show version information"`
+	Doctor      command.DoctorCmd      `cmd:"" help:"Check consistency of project structure and repositories"`
+	Version     command.VersionCmd     `cmd:"" help:"Show devslot version"`
+
+	VersionFlag kong.VersionFlag `short:"v" name:"version" help:"Show version"`
 }
 
 type App struct {
@@ -28,13 +30,16 @@ func NewApp(writer io.Writer) *App {
 	cli := &CLI{}
 	parser, err := kong.New(cli,
 		kong.Name("devslot"),
-		kong.Description("A development environment manager for multi-repository worktrees"),
+		kong.Description("Development environment manager for multi-repo worktrees"),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact: true,
 		}),
 		kong.Writers(writer, writer),
 		kong.Exit(func(int) {}), // Override exit for testing
+		kong.Vars{
+			"version": "dev", // This should be set by ldflags during build
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/devslot/main.go
+++ b/cmd/devslot/main.go
@@ -32,7 +32,7 @@ func NewApp(writer io.Writer) *App {
 		writer:      writer,
 		exitHandler: os.Exit,
 	}
-	
+
 	cli := &CLI{}
 	parser, err := kong.New(cli,
 		kong.Name("devslot"),

--- a/cmd/devslot/main_test.go
+++ b/cmd/devslot/main_test.go
@@ -13,6 +13,12 @@ func TestApp_Run(t *testing.T) {
 		wantOutputText string
 	}{
 		{
+			name:           "no arguments shows help",
+			args:           []string{},
+			wantErr:        false,
+			wantOutputText: "Usage: devslot <command>",
+		},
+		{
 			name:           "help command",
 			args:           []string{"--help"},
 			wantErr:        true, // kong returns an error for help

--- a/cmd/devslot/main_test.go
+++ b/cmd/devslot/main_test.go
@@ -15,7 +15,7 @@ func TestApp_Run(t *testing.T) {
 		{
 			name:           "no arguments shows help",
 			args:           []string{},
-			wantErr:        false,
+			wantErr:        true, // kong returns error for help
 			wantOutputText: "Usage: devslot <command>",
 		},
 		{
@@ -42,6 +42,12 @@ func TestApp_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			app := NewApp(&buf)
+			
+			// Override exit handler for testing
+			exitCode := -1
+			app.SetExitHandler(func(code int) {
+				exitCode = code
+			})
 
 			err := app.Run(tt.args)
 			if (err != nil) != tt.wantErr {
@@ -52,6 +58,13 @@ func TestApp_Run(t *testing.T) {
 				output := buf.String()
 				if !contains(output, tt.wantOutputText) {
 					t.Errorf("App.Run() output = %v, want to contain %v", output, tt.wantOutputText)
+				}
+			}
+			
+			// For help cases, check that exit was called with 0
+			if tt.name == "help command" || tt.name == "no arguments shows help" {
+				if exitCode != 0 {
+					t.Errorf("Expected exit code 0 for help, got %d", exitCode)
 				}
 			}
 		})

--- a/cmd/devslot/main_test.go
+++ b/cmd/devslot/main_test.go
@@ -42,7 +42,7 @@ func TestApp_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			app := NewApp(&buf)
-			
+
 			// Override exit handler for testing
 			exitCode := -1
 			app.SetExitHandler(func(code int) {
@@ -60,7 +60,7 @@ func TestApp_Run(t *testing.T) {
 					t.Errorf("App.Run() output = %v, want to contain %v", output, tt.wantOutputText)
 				}
 			}
-			
+
 			// For help cases, check that exit was called with 0
 			if tt.name == "help command" || tt.name == "no arguments shows help" {
 				if exitCode != 0 {


### PR DESCRIPTION
## Summary
- Update help messages to match actual implementation
- Fix double help display issue by removing UsageOnError()
- Show help automatically when no arguments provided
- Implement proper help handling using Kong's exit mechanism

## Changes
1. **Help message improvements**:
   - Updated command descriptions to be consistent with README
   - Added -v/--version flag support
   - Adjusted descriptions for clarity

2. **Fix double help display**:
   - Removed `UsageOnError()` which was causing help to display twice
   - Help now displays only once as expected

3. **No-args behavior**:
   - Running `devslot` without arguments now shows help
   - Makes the CLI more user-friendly

4. **Proper help handling**:
   - Added exitHandler to support Kong's natural exit behavior
   - Help display now properly prevents command execution
   - Maintains testability with custom exit handler

## Test plan
- [x] Help displays correctly for all commands
- [x] No double help display
- [x] Commands don't execute after help is shown
- [x] Unit tests pass
- [x] E2E tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)