### PR TITLE
Add executable hook scripts to boilerplate command

### DIFF
--- a/internal/command/boilerplate.go
+++ b/internal/command/boilerplate.go
@@ -71,15 +71,20 @@ Thumbs.db
 	ctx.Printf("Updated file: .gitignore\n")
 	ctx.LogInfo(".gitignore updated")
 
-	// Create hook examples
-	hookExamples := map[string]string{
+	// Create hook scripts with executable permissions
+	hookScripts := map[string]string{
 		"post-create": `#!/bin/bash
 # This hook is called after a new slot is created
 # Environment variables:
 #   DEVSLOT_SLOT: The name of the slot
 #   DEVSLOT_PROJECT_ROOT: The root directory of the project
 
-echo "Slot $DEVSLOT_SLOT has been created!"
+# Example output (comment out if not needed)
+# echo "🎉 Post-create hook executed!"
+# echo "Slot: $DEVSLOT_SLOT"
+# echo "Project root: $DEVSLOT_PROJECT_ROOT"
+# echo "Working dir: $(pwd)"
+# echo "Hook executed at: $(date)"
 
 # Example: Install dependencies for each repository
 # for repo in "$DEVSLOT_PROJECT_ROOT/slots/$DEVSLOT_SLOT"/*; do
@@ -88,6 +93,13 @@ echo "Slot $DEVSLOT_SLOT has been created!"
 #         (cd "$repo" && npm install)
 #     fi
 # done
+
+# Example: Set up development environment
+# echo "Setting up development environment for $DEVSLOT_SLOT..."
+# Copy environment files, install tools, etc.
+
+# Example: Send notification
+# echo "Slot $DEVSLOT_SLOT is ready!" | notify-send "DevSlot" || true
 `,
 		"pre-destroy": `#!/bin/bash
 # This hook is called before a slot is destroyed
@@ -95,12 +107,28 @@ echo "Slot $DEVSLOT_SLOT has been created!"
 #   DEVSLOT_SLOT: The name of the slot
 #   DEVSLOT_PROJECT_ROOT: The root directory of the project
 
-echo "Slot $DEVSLOT_SLOT will be destroyed!"
+# Example output (comment out if not needed)
+# echo "🗑️ Pre-destroy hook executed!"
+# echo "About to destroy slot: $DEVSLOT_SLOT"
+# echo "Project root: $DEVSLOT_PROJECT_ROOT"
+# echo "Working dir: $(pwd)"
+
+# Example: Check for uncommitted changes
+# for repo in "$DEVSLOT_PROJECT_ROOT/slots/$DEVSLOT_SLOT"/*; do
+#     if [ -d "$repo/.git" ]; then
+#         if [ -n "$(cd "$repo" && git status --porcelain)" ]; then
+#             echo "WARNING: Uncommitted changes in $(basename "$repo")"
+#             # Optionally exit with error to prevent destruction
+#             # exit 1
+#         fi
+#     fi
+# done
 
 # Example: Backup important files
 # backup_dir="$DEVSLOT_PROJECT_ROOT/backups/$DEVSLOT_SLOT-$(date +%Y%m%d-%H%M%S)"
 # mkdir -p "$backup_dir"
 # echo "Backing up slot to $backup_dir..."
+# cp -r "$DEVSLOT_PROJECT_ROOT/slots/$DEVSLOT_SLOT" "$backup_dir/"
 `,
 		"post-reload": `#!/bin/bash
 # This hook is called after a slot is reloaded
@@ -108,20 +136,34 @@ echo "Slot $DEVSLOT_SLOT will be destroyed!"
 #   DEVSLOT_SLOT: The name of the slot
 #   DEVSLOT_PROJECT_ROOT: The root directory of the project
 
-echo "Slot $DEVSLOT_SLOT has been reloaded!"
+# Example output (comment out if not needed)
+# echo "🔄 Post-reload hook executed!"
+# echo "Reloaded slot: $DEVSLOT_SLOT"
+# echo "Project root: $DEVSLOT_PROJECT_ROOT"
+# echo "Working dir: $(pwd)"
 
 # Example: Sync dependencies or update configurations
-# echo "Updating dependencies..."
+# echo "Updating dependencies for $DEVSLOT_SLOT..."
+# for repo in "$DEVSLOT_PROJECT_ROOT/slots/$DEVSLOT_SLOT"/*; do
+#     if [ -f "$repo/package.json" ]; then
+#         echo "Updating npm dependencies in $(basename "$repo")..."
+#         (cd "$repo" && npm install)
+#     fi
+# done
+
+# Example: Run migrations or update database schema
+# echo "Running database migrations..."
+# (cd "$DEVSLOT_PROJECT_ROOT/slots/$DEVSLOT_SLOT/main-app" && npm run migrate)
 `,
 	}
 
-	for hookName, content := range hookExamples {
-		hookPath := filepath.Join(currentDir, "hooks", hookName+".example")
-		if err := createFileIfNotExists(hookPath, content); err != nil {
-			return fmt.Errorf("failed to create hook example %s: %w", hookName, err)
+	for hookName, content := range hookScripts {
+		hookPath := filepath.Join(currentDir, "hooks", hookName)
+		if err := createExecutableFile(hookPath, content); err != nil {
+			return fmt.Errorf("failed to create hook script %s: %w", hookName, err)
 		}
-		ctx.Printf("Created hook example: hooks/%s.example\n", hookName)
-		ctx.LogInfo("hook example created", "hook", hookName)
+		ctx.Printf("Created hook script: hooks/%s\n", hookName)
+		ctx.LogInfo("hook script created", "hook", hookName)
 	}
 
 	ctx.Println("\nBoilerplate project structure created successfully!")
@@ -140,6 +182,14 @@ func createFileIfNotExists(path, content string) error {
 	}
 
 	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func createExecutableFile(path, content string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil // File already exists
+	}
+
+	return os.WriteFile(path, []byte(content), 0755)
 }
 
 func createOrAppendToFile(path, content string) error {

--- a/internal/command/boilerplate_test.go
+++ b/internal/command/boilerplate_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,9 +33,9 @@ func TestBoilerplateCmd_Run(t *testing.T) {
 		"Created directory: slots",
 		"Created file: devslot.yaml",
 		"Updated file: .gitignore",
-		"Created hook example: hooks/post-create.example",
-		"Created hook example: hooks/pre-destroy.example",
-		"Created hook example: hooks/post-reload.example",
+		"Created hook script: hooks/post-create",
+		"Created hook script: hooks/pre-destroy",
+		"Created hook script: hooks/post-reload",
 		"Boilerplate project structure created successfully!",
 	}
 
@@ -57,9 +58,9 @@ func TestBoilerplateCmd_Run(t *testing.T) {
 	files := []string{
 		"devslot.yaml",
 		".gitignore",
-		"hooks/post-create.example",
-		"hooks/pre-destroy.example",
-		"hooks/post-reload.example",
+		"hooks/post-create",
+		"hooks/pre-destroy",
+		"hooks/post-reload",
 	}
 	for _, file := range files {
 		filePath := filepath.Join(tempDir, file)
@@ -81,6 +82,25 @@ func TestBoilerplateCmd_Run(t *testing.T) {
 	gitignore := testutil.ReadFile(t, filepath.Join(tempDir, ".gitignore"))
 	if !contains(gitignore, "/repos/") || !contains(gitignore, "/slots/") {
 		t.Error(".gitignore missing devslot directories")
+	}
+
+	// Check hook files are executable
+	hookFiles := []string{
+		"hooks/post-create",
+		"hooks/pre-destroy",
+		"hooks/post-reload",
+	}
+	for _, hook := range hookFiles {
+		hookPath := filepath.Join(tempDir, hook)
+		info, err := os.Stat(hookPath)
+		if err != nil {
+			t.Errorf("Failed to get file info for %s: %v", hook, err)
+			continue
+		}
+		// Check if executable (0755 = -rwxr-xr-x)
+		if info.Mode().Perm() != 0755 {
+			t.Errorf("Hook file %s has incorrect permissions: %v (expected 0755)", hook, info.Mode().Perm())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `.example` hook files with executable scripts (755 permissions)
- Add commented example code showing environment variables and practical use cases
- Ensure hooks are ready to use immediately after `devslot boilerplate` command

## Changes
- Modified `boilerplate.go` to create executable hook scripts instead of example files
- Added `createExecutableFile()` function to write files with 755 permissions
- Enhanced hook scripts with:
  - Example output showing environment variables (`DEVSLOT_SLOT`, `DEVSLOT_PROJECT_ROOT`)
  - Practical examples for each hook type:
    - **post-create**: dependency installation, environment setup, notifications
    - **pre-destroy**: uncommitted changes check, backup functionality
    - **post-reload**: dependency updates, database migrations
- Updated tests to verify hook files have correct executable permissions

## Test plan
- [x] Run `devslot boilerplate` and verify hooks are created with 755 permissions
- [x] Verify hook scripts contain commented examples
- [x] Run unit tests: `go test ./internal/command -run TestBoilerplateCmd`
- [x] All quality checks pass: `make check.all`

🤖 Generated with [Claude Code](https://claude.ai/code)