### PR TITLE
Remove Windows support from GoReleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     goarch:
       - amd64
@@ -29,9 +28,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    format_overrides:
-      - goos: windows
-        format: zip
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
## Summary
- Remove Windows from GoReleaser build targets to fix release workflow failures
- Prevent syscall.Flock compilation errors on Windows platform

## Problem
The release workflow has been failing with the following error when building for Windows:
```
internal/lock/lock.go:27:16: undefined: syscall.Flock
internal/lock/lock.go:27:46: undefined: syscall.LOCK_EX
internal/lock/lock.go:27:62: undefined: syscall.LOCK_NB
internal/lock/lock.go:57:17: undefined: syscall.Flock
internal/lock/lock.go:57:49: undefined: syscall.LOCK_UN
```

This is because `syscall.Flock` is not available on Windows, only on Unix-like systems (Linux, macOS).

## Solution
Remove Windows from the build targets in `.goreleaser.yaml` since Windows support is not required for this tool.

## Changes
- Remove `windows` from the `goos` list in `.goreleaser.yaml`
- Remove Windows-specific archive format override

## Test plan
- [x] Test GoReleaser build locally: `goreleaser build --snapshot --clean --single-target`
- [x] Verify configuration is valid: `goreleaser check`

🤖 Generated with [Claude Code](https://claude.ai/code)