### PR TITLE
feat: add detailed help text for all commands

### DIFF
--- a/internal/command/boilerplate.go
+++ b/internal/command/boilerplate.go
@@ -10,6 +10,24 @@ type BoilerplateCmd struct {
 	Dir string `arg:"" required:"" help:"Directory to create project structure in (use . for current directory)"`
 }
 
+func (c *BoilerplateCmd) Help() string {
+	return `Creates initial project structure for devslot.
+
+Creates the following:
+  - devslot.yaml    (project configuration template)
+  - .gitignore      (ignores repos/ and slots/)
+  - hooks/          (optional lifecycle scripts)
+    - post-init     (runs after 'devslot init')
+    - post-create   (runs after 'devslot create')
+    - pre-destroy   (runs before 'devslot destroy')
+    - post-reload   (runs after 'devslot reload')
+  - repos/          (for bare repositories)
+  - slots/          (for worktrees)
+
+Creates the target directory if it doesn't exist.
+All hooks are optional and include helpful examples.`
+}
+
 func (c *BoilerplateCmd) Run(ctx *Context) error {
 	// Resolve target directory
 	targetDir := c.Dir

--- a/internal/command/create.go
+++ b/internal/command/create.go
@@ -13,7 +13,23 @@ import (
 
 type CreateCmd struct {
 	SlotName string `arg:"" help:"Name of the slot to create"`
-	Branch   string `short:"b" help:"Branch to checkout (if not specified, creates new branch with automatic naming)"`
+	Branch   string `short:"b" help:"Branch to checkout (if not specified, creates new branch named devslot/<git-email-localpart>/<slot-name>)"`
+}
+
+func (c *CreateCmd) Help() string {
+	return `Creates a new slot with git worktrees for all repositories.
+
+When -b/--branch is not specified, a new branch is created with the naming pattern:
+  devslot/<prefix>/<slot-name>
+
+The <prefix> is determined by (in order of precedence):
+  1. DEVSLOT_BRANCH_PREFIX environment variable
+  2. git config devslot.branchPrefix
+  3. Local part of git user.email (e.g., "john.doe" from "john.doe@example.com")
+  4. "user" (fallback)
+
+Example: For user "john.doe@example.com" creating slot "feature-x":
+  Branch name: devslot/john-doe/feature-x`
 }
 
 func (c *CreateCmd) Run(ctx *Context) error {

--- a/internal/command/destroy.go
+++ b/internal/command/destroy.go
@@ -14,6 +14,13 @@ type DestroyCmd struct {
 	SlotName string `arg:"" help:"Name of the slot to destroy"`
 }
 
+func (c *DestroyCmd) Help() string {
+	return `Removes a slot and all its worktrees.
+
+Runs pre-destroy hook if it exists. If the hook fails (non-zero exit),
+the destruction is aborted and the slot remains intact.`
+}
+
 func (c *DestroyCmd) Run(ctx *Context) error {
 	// Find project root
 	currentDir, err := os.Getwd()

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -18,6 +18,18 @@ type InitCmd struct {
 	AllowDelete bool `help:"Delete repositories no longer listed in devslot.yaml"`
 }
 
+func (c *InitCmd) Help() string {
+	return `Clones repositories defined in devslot.yaml as bare repositories into repos/.
+
+This command:
+  - Only clones missing repositories (skips existing ones)
+  - Does not affect existing slots or worktrees
+  - Preserves unlisted repositories unless --allow-delete is used
+  - Runs post-init hook if it exists
+
+Safe to run multiple times.`
+}
+
 func (c *InitCmd) Run(ctx *Context) error {
 	// Find project root
 	currentDir, err := os.Getwd()

--- a/internal/command/reload.go
+++ b/internal/command/reload.go
@@ -14,6 +14,13 @@ type ReloadCmd struct {
 	SlotName string `arg:"" help:"Name of the slot to reload"`
 }
 
+func (c *ReloadCmd) Help() string {
+	return `Ensures all repositories are checked out as worktrees for the slot.
+
+Automatically creates any missing worktrees (useful after adding new
+repositories to devslot.yaml). Runs post-reload hook if it exists.`
+}
+
 func (c *ReloadCmd) Run(ctx *Context) error {
 	// Find project root
 	currentDir, err := os.Getwd()


### PR DESCRIPTION
## Summary

This PR enhances the help text for all devslot commands to include important behavioral specifications that were previously only documented in the README.

## Changes

- Added Help() methods to all command structs to provide detailed documentation
- Documented the automatic branch naming pattern for the create command
- Clarified hook behaviors and failure handling for commands that use hooks
- Explained safety guarantees (e.g., init won't disturb existing work)
- Listed all files/directories created by the boilerplate command

## Motivation

Users should be able to understand important command behaviors without needing to consult the README. The enhanced help text includes:

- **create**: Full details on branch naming pattern including customization options
- **init**: Clarification that it's safe to run multiple times
- **destroy**: Documentation that pre-destroy hooks can prevent deletion
- **reload**: Explanation that it automatically creates missing worktrees
- **boilerplate**: Complete list of created files and directories

## Test

Run any command with --help to see the enhanced documentation:

devslot create --help
devslot init --help
devslot boilerplate --help

🤖 Generated with Claude