### PR TITLE
docs: add binary download instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,32 @@ devslot helps you manage multiple Git repositories as a cohesive development env
 
 ## Installation
 
+### Download Binary
+
+Download the latest binary from the [releases page](https://github.com/yammerjp/devslot/releases).
+
+#### macOS
+```bash
+# Intel Mac
+curl -L https://github.com/yammerjp/devslot/releases/latest/download/devslot_Darwin_x86_64.tar.gz | tar xz
+sudo mv devslot /usr/local/bin/
+
+# Apple Silicon Mac
+curl -L https://github.com/yammerjp/devslot/releases/latest/download/devslot_Darwin_arm64.tar.gz | tar xz
+sudo mv devslot /usr/local/bin/
+```
+
+#### Linux
+```bash
+# x86_64
+curl -L https://github.com/yammerjp/devslot/releases/latest/download/devslot_Linux_x86_64.tar.gz | tar xz
+sudo mv devslot /usr/local/bin/
+
+# ARM64
+curl -L https://github.com/yammerjp/devslot/releases/latest/download/devslot_Linux_arm64.tar.gz | tar xz
+sudo mv devslot /usr/local/bin/
+```
+
 ### Using Go
 
 ```bash


### PR DESCRIPTION
## Summary

Add binary download instructions as the primary installation method in the README.

## Changes

- Added detailed download instructions for pre-built binaries
- Covered all supported platforms:
  - macOS: Intel (x86_64) and Apple Silicon (arm64)
  - Linux: x86_64 and ARM64
- Included one-liner curl commands for easy installation
- Moved binary download to the top of installation methods (most users prefer pre-built binaries)

## Why

Most users prefer downloading pre-built binaries rather than building from source or having Go installed. This makes devslot more accessible to a wider audience.

🤖 Generated with Claude